### PR TITLE
chore: make sure build-branch only runs on branches, and the releases…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   build-branch:
     runs-on: ubuntu-latest
+    if: ${{ github.ref_type != 'tag' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -37,6 +38,7 @@ jobs:
 
   build-releases:
     runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
     strategy:
       matrix:
         version: ['main', 'udp']


### PR DESCRIPTION
… workflow only runs on tags